### PR TITLE
fix(leaflet map): zoom out to display more of the surroundings

### DIFF
--- a/src/scripts/components/leaflet-map/index.js
+++ b/src/scripts/components/leaflet-map/index.js
@@ -14,7 +14,7 @@ export default function initializeMap(mapElement) {
   const coordinates = [mapElement.dataset.latitude, mapElement.dataset.longitude]
   const map = L.map(mapElement, {
     center: coordinates,
-    zoom: 20,
+    zoom: 16,
   })
   L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
     attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',


### PR DESCRIPTION
## Ticket description
> DESKTOP + MOBILE : Dézoomer la clinique sur le module Open street map

## Ticket resolution
- change zoom to `16` instead of `20`